### PR TITLE
Implement basic doPost endpoint

### DIFF
--- a/src/slack/slackBot.gs
+++ b/src/slack/slackBot.gs
@@ -1,0 +1,5 @@
+function doPost(e) {
+  // Log the incoming payload for debugging
+  console.log(JSON.stringify(e));
+  return ContentService.createTextOutput('Received');
+}


### PR DESCRIPTION
## Summary
- add `src/slack/slackBot.gs` with a minimal `doPost` function to log incoming Slack slash command payloads

## Testing
- `git status --short`